### PR TITLE
Modified all scripts and core files that gave errors when run with Python 3.6

### DIFF
--- a/pyaci/__init__.py
+++ b/pyaci/__init__.py
@@ -16,5 +16,5 @@ __copyright__ = 'Copyright (c) 2015 Cisco Systems, Inc. All rights reserved.'
 
 
 from .core import Node
-import options
-import filters
+import pyaci.options
+import pyaci.filters

--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -14,6 +14,7 @@ from requests import Request
 from threading import Event
 from io import BytesIO
 from functools import reduce
+from six import iteritems, iterkeys, itervalues
 import base64
 import getpass
 import json
@@ -98,7 +99,7 @@ class Api(object):
 
         if kwargs:
             options = '?'
-            for key, value in kwargs.items():
+            for key, value in iteritems(kwargs):
                 options += (key + '=' + value + '&')
         else:
             options = ''
@@ -292,10 +293,7 @@ class MoIter(Api):
         self._objects = objects
         self._aciClassMeta = aciClassMetas[self._className]
         self._rnFormat = self._aciClassMeta['rnFormat']
-        try:
-            self._iter = self._objects.itervalues()
-        except AttributeError:
-            self._iter = self._objects.values()
+        self._iter = itervalues(self._objects)
 
     def __call__(self, *args, **kwargs):
         identifiedBy = self._aciClassMeta['identifiedBy']
@@ -413,10 +411,7 @@ class Mo(Api):
 
     @property
     def Children(self):
-        try:
-            return self._children.itervalues()
-        except AttributeError:
-            return self._children.values()
+        return itervalues(self._children)
 
     @property
     def Status(self):
@@ -527,10 +522,7 @@ class Mo(Api):
             subscriptionIds.extend(sIds)
         mos = []
         for element in response['imdata']:
-            try:
-                name, value = element.iteritems().next()
-            except AttributeError:
-                name, value = element.items()
+            name, value = next(iteritems(element))
             assert 'dn' in value['attributes']
             mo = self.FromDn(value['attributes']['dn'])
             mo._fromObjectDict(element)
@@ -573,12 +565,8 @@ class Mo(Api):
 
         children = objectDict[self._className].get('children', [])
         for cdict in children:
-            try:
-                className = cdict.iterkeys().next()
-                attributes = cdict.itervalues().next().get('attributes', {})
-            except AttributeError:
-                className = cdict.keys().next()
-                attributes = cdict.values().next().get('attributes', {})
+            className = next(iterkeys(cdict))
+            attributes = next(itervalues(cdict)).get('attributes', {})
             child = self._spawnChildFromAttributes(className, **attributes)
             child._fromObjectDict(cdict)
 

--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -494,7 +494,7 @@ class Mo(Api):
     def ParseXmlResponse(self, xml, localOnly=False, subscriptionIds=[]):
         # https://gist.github.com/karlcow/3258330
         xml = bytes(bytearray(xml, encoding='utf-8'))
-        context = etree.iterparse(StringIO.StringIO(xml),
+        context = etree.iterparse(StringIO(xml),
                                   events=('end',), tag='imdata')
         mos = []
         event, root = next(context)
@@ -520,7 +520,7 @@ class Mo(Api):
             subscriptionIds.extend(sIds)
         mos = []
         for element in response['imdata']:
-            name, value = element.items().next()
+            name, value = element.items()
             assert 'dn' in value['attributes']
             mo = self.FromDn(value['attributes']['dn'])
             mo._fromObjectDict(element)
@@ -563,8 +563,8 @@ class Mo(Api):
 
         children = objectDict[self._className].get('children', [])
         for cdict in children:
-            className = cdict.keys().next()
-            attributes = cdict.values().next().get('attributes', {})
+            className = cdict.keys()
+            attributes = cdict.values().get('attributes', {})
             child = self._spawnChildFromAttributes(className, **attributes)
             child._fromObjectDict(cdict)
 

--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -24,7 +24,10 @@ import requests
 import ssl
 import threading
 import websocket
-from urllib.parse import unquote
+try:
+    from urllib.parse import unquote
+except ImportError:
+    from urllib import unquote
 
 from .errors import (
     MetaError, MoError, ResourceError, RestError, UserError

--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -12,7 +12,7 @@ from collections import defaultdict, deque
 from lxml import etree
 from requests import Request
 from threading import Event
-import StringIO
+from io import StringIO
 import base64
 import getpass
 import json
@@ -24,7 +24,7 @@ import requests
 import ssl
 import threading
 import websocket
-from urllib import unquote
+from urllib.parse import unquote
 
 from .errors import (
     MetaError, MoError, ResourceError, RestError, UserError
@@ -94,7 +94,7 @@ class Api(object):
 
         if kwargs:
             options = '?'
-            for key, value in kwargs.iteritems():
+            for key, value in kwargs.items():
                 options += (key + '=' + value + '&')
         else:
             options = ''
@@ -288,7 +288,7 @@ class MoIter(Api):
         self._objects = objects
         self._aciClassMeta = aciClassMetas[self._className]
         self._rnFormat = self._aciClassMeta['rnFormat']
-        self._iter = self._objects.itervalues()
+        self._iter = self._objects.values()
 
     def __call__(self, *args, **kwargs):
         identifiedBy = self._aciClassMeta['identifiedBy']
@@ -406,7 +406,7 @@ class Mo(Api):
 
     @property
     def Children(self):
-        return self._children.itervalues()
+        return self._children.values()
 
     @property
     def Status(self):
@@ -517,7 +517,7 @@ class Mo(Api):
             subscriptionIds.extend(sIds)
         mos = []
         for element in response['imdata']:
-            name, value = element.iteritems().next()
+            name, value = element.items().next()
             assert 'dn' in value['attributes']
             mo = self.FromDn(value['attributes']['dn'])
             mo._fromObjectDict(element)
@@ -555,13 +555,13 @@ class Mo(Api):
     def _fromObjectDict(self, objectDict):
         attributes = objectDict[self._className].get('attributes', {})
 
-        for key, value in attributes.iteritems():
+        for key, value in attributes.items():
             self._properties[key] = value
 
         children = objectDict[self._className].get('children', [])
         for cdict in children:
-            className = cdict.iterkeys().next()
-            attributes = cdict.itervalues().next().get('attributes', {})
+            className = cdict.keys().next()
+            attributes = cdict.values().next().get('attributes', {})
             child = self._spawnChildFromAttributes(className, **attributes)
             child._fromObjectDict(cdict)
 

--- a/pyaci/filters.py
+++ b/pyaci/filters.py
@@ -38,11 +38,11 @@ class Not(UnaryFilter):
     _operator = 'not'
 
 
-class True(UnaryFilter):
+class CheckTrue(UnaryFilter):
     _operator = 'true'
 
 
-class False(UnaryFilter):
+class CheckFalse(UnaryFilter):
     _operator = 'false'
 
 

--- a/pyaci/query.py
+++ b/pyaci/query.py
@@ -83,7 +83,7 @@ class Index(object):
                                                      value)
                     return filter(pred, self._objectsByClass[className])
             except Exception as e:
-                print e
+                print(e)
 
         return self._objectsByClass[className]
 

--- a/pyaci/templating.py
+++ b/pyaci/templating.py
@@ -18,7 +18,7 @@ def mergeDict(master, other):
     """Merge the given two dictionaries recursively and return the
     result."""
     if isinstance(master, dict) and isinstance(other, dict):
-        for key, value in other.iteritems():
+        for key, value in other.items():
             if isinstance(value, dict):
                 if key not in master:
                     master[key] = value

--- a/pyaci/utils.py
+++ b/pyaci/utils.py
@@ -10,6 +10,7 @@ This module contains PyACI utility functions.
 from contextlib import contextmanager
 import logging
 import tarfile
+from functools import reduce
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/lmetagen.py
+++ b/scripts/lmetagen.py
@@ -25,19 +25,19 @@ def main():
         limitedClassMetas[className] = copy.deepcopy(aciClassMetas[className])
 
         limitedClassMetas[className]['contains'] = {}
-        for key, value in aciClassMetas[className]['contains'].iteritems():
+        for key, value in aciClassMetas[className]['contains'].items():
             if key in limitedClasses:
                 limitedClassMetas[className]['contains'][key] = value
 
         limitedClassMetas[className]['rnMap'] = {}
-        for key, value in aciClassMetas[className]['rnMap'].iteritems():
+        for key, value in aciClassMetas[className]['rnMap'].items():
             if value in limitedClasses:
                 limitedClassMetas[className]['rnMap'][key] = value
 
     limitedMeta = {}
     limitedMeta['classes'] = limitedClassMetas
 
-    with open('aci-meta.json', 'wb') as out:
+    with open('aci-meta.json', 'w') as out:
         json.dump(limitedMeta, out,
                   sort_keys=True, indent=2, separators=(',', ': '))
 

--- a/scripts/metagen.py
+++ b/scripts/metagen.py
@@ -78,7 +78,7 @@ def main():
     aciClassMetas = pool.imap(generateClassMeta, classNames)
     aciMeta['classes'] = dict(aciClassMetas)
 
-    with open('aci-meta.json', 'wb') as out:
+    with open('aci-meta.json', 'w') as out:
         json.dump(aciMeta, out,
                   sort_keys=True, indent=2, separators=(',', ': '))
 


### PR DESCRIPTION
I did some changes on the files that thrown errors while used with python3. 
Main changes involve:
- iteritems/itervalues/iterkeys methods on dictionaries are no longer supported
- use relative imports for own modules
- changes to accommodate differences for some python libraries (io, urllib, json)
- builtin 'file' type no longer exists
- changed name for functions 'True' and 'False' in filters.py as they interfered 