### PR TITLE
Fix "no existing session" paramiko crash

### DIFF
--- a/scripts/rmetagen.py
+++ b/scripts/rmetagen.py
@@ -41,8 +41,9 @@ def main():
 
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    ssh.connect(args.host[0], port=args.port,
-                username=args.user, password=args.password)
+    ssh.connect(args.host[0], port=args.port, username=args.user,
+                password=args.password, allow_agent=False,
+                look_for_keys=False)
     stdin, stdout, stderr = ssh.exec_command('acidiag version')
     version = ''.join(stdout.readlines()).strip()
     vlist = version.split('.')


### PR DESCRIPTION
When I tried to run rmetagen.py on MacOS X, I got the following traceback:

```
Traceback (most recent call last):
  File "/Users/user/virtualenvs/pyaci2/bin/rmetagen.py", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/user/learning/aci/pyaci-master/scripts/rmetagen.py", line 96, in <module>
    main()
  File "/Users/user/learning/aci/pyaci-master/scripts/rmetagen.py", line 45, in main
    username=args.user, password=args.password)
  File "/Users/user/virtualenvs/pyaci2/lib/python2.7/site-packages/paramiko/client.py", line 424, in connect
    passphrase,
  File "/Users/user/virtualenvs/pyaci2/lib/python2.7/site-packages/paramiko/client.py", line 714, in _auth
    raise saved_exception
```

I'm guessing this is because of differences with the Linux ssh-agent.  This patch fixes the issue by bypassing the ssh-agent.