### PR TITLE
Enable Python 3 in shippable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dist
 *.pyc
 .pyenv-version
 examples/.ipynb_checkpoints/
+.vscode
+.noseids
+.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'pyyaml',
         'requests',
         'scp',
+        'six',
         'websocket-client',
     ],
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,6 +1,12 @@
 language: python
 python:
   - 2.7
+  - 3.6
+
+build:
+  pre_ci_boot:
+    image_name: drydock/u16pytall
+    image_tag: v6.2.2
 
 before_script:
   - mkdir -p shippable/testresults


### PR DESCRIPTION
`six` was not explicitly listed as a dependency. We got lucky because other packages were depending on it. List `six` as explicit dependency.