### PR TITLE
added AppLoginMethod to support aaaRequestToken api

### DIFF
--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -129,7 +129,7 @@ class Api(object):
         req = Request(method, url, data=data)
         prepped = rootApi._session.prepare_request(req)
         # never use certificate for subscription requests
-        if "subscription" not in kwargs.keys():
+        if "subscription" not in kwargs:
             self._x509Prep(rootApi, prepped, data)
         response = rootApi._session.send(prepped, verify=rootApi._verify, timeout=rootApi._timeout)
 


### PR DESCRIPTION
ACI appcenter users are dynamically created when an app is installed. An
aaaAppUser is created with certificate files used for accessing APIC API. To
support websockets (which require a token), the aaaRequestApi was added
allowing aaaAppUsers to request a token via certificate based authentication.

The AppLoginMethod supports POST which will save the APIC-cookie cookie to the
active session object allowing future websocket GET requests to work.

Example:

apic = Node(apicUrl)
apic.useX509CertAuth(appUserName, appCertName, pKeyFile, appcenter=True)
apic.methods.AppLogin(appUserName).POST()
apic.startWsListener()
tenants, subId = apic.methods.ResolveClass("fvTenant").GET(**options.subscribe)