### PR TITLE
 Add a utility to convert XML to Python.

### DIFF
--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -783,6 +783,8 @@ class LoginRefreshMethod(Api):
     def _relativeUrl(self):
         return 'aaaRefresh'
 
+    def __call__(self):
+        return self
 
 class ChangeCertMethod(Api):
     def __init__(self, parentApi):

--- a/scripts/xml2pyaci
+++ b/scripts/xml2pyaci
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+
+from lxml import etree
+
+# Given an input file that is an ACI XML, `xml2py` utility can generate the
+# corresponding PyACI Python code.
+
+def main():
+    args = parseArgs()
+    convert(args.input, args.output)
+
+
+def parseArgs():
+    parser = argparse.ArgumentParser(
+        description='Convert ACI XML file to PyACI code snippet')
+    parser.add_argument('input', metavar='INPUT', type=str,
+                        help='input XML file path')
+    parser.add_argument('output', metavar='OUTPUT', type=str,
+                        help='output Python file path')
+    return parser.parse_args()
+
+
+def convert(inFile, outFile):
+    with open(inFile) as fin:
+        tree = etree.parse(fin)
+        with open(outFile, 'w') as fout:
+            print('from pyaci import Node', file=fout)
+            print("\n\nnode = Node('https://APIC')", file=fout)
+            print("# node.methods.Login('admin', 'password').POST()",
+                  file=fout)
+            print('mit = node.mit', file=fout)
+            emitNode(fout, 'mit', tree.getroot())
+
+
+def emitNode(fout, parent, node):
+    me = node.tag
+    if me is etree.Comment:
+        print('#', node.text, file=fout)
+    else:
+        if node.getchildren():
+            prefix = '{} = '.format(me)
+        else:
+            prefix = ''
+        args = []
+        for name, value in node.attrib.items():
+            args.append("{}='{}'".format(name, value))
+        args = ', '.join(args)
+        print('{}{}.{}({})'.format(prefix, parent, me, args), file=fout)
+    for child in node.iterchildren():
+        emitNode(fout, me, child)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,6 @@ setup(
     scripts=[
         'scripts/metagen.py',
         'scripts/rmetagen.py',
+        'scripts/xml2pyaci',
     ]
 )


### PR DESCRIPTION
Given an input that is an ACI XML, `xml2pyaci` utility can generate the
corresponding PyACI Python code.

Additionally, fix a style issue with `LoginRefreshMethod`. It is the only method that could be used without treating as a function, as this doesn't take any argument. Make `__call__()` return itself, so that it can also be used like a nullary function.