### PR TITLE
Allow to POST and MO directly in the hierarchy

### DIFF
--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -87,11 +87,11 @@ class Api(object):
     def DELETE(self, format=None):
         return self._performRequest('DELETE', format=format)
 
-    def POST(self, format=None, **kwargs):
+    def POST(self, format=None, useParentUrl=False, **kwargs):
         return self._performRequest(
-            'POST', format=format, needData=True, **kwargs)
+            'POST', format=format, needData=True, useParentUrl=useParentUrl, **kwargs)
 
-    def _url(self, format=None, **kwargs):
+    def _url(self, format=None, useParentUrl=False, **kwargs):
         if format is None:
             format = payloadFormat
 
@@ -117,15 +117,18 @@ class Api(object):
         else:
             options = ''
 
-        return loop(self, '') + '.' + format + options
+        if useParentUrl:
+            return loop(self._parentApi, '') + '.' + format + options
+        else:
+            return loop(self, '') + '.' + format + options
 
-    def _performRequest(self, method, format=None, needData=False, **kwargs):
+    def _performRequest(self, method, format=None, needData=False, useParentUrl=False,  **kwargs):
         if format is None:
             format = payloadFormat
 
         logger = subLogger(method)
         rootApi = self._rootApi()
-        url = self._url(format, **kwargs)
+        url = self._url(format, useParentUrl=useParentUrl, **kwargs)
 
         if needData:
             if format == 'json':
@@ -619,6 +622,9 @@ class Mo(Api):
             return result, subscriptionIds[0]
         else:
             return result
+
+    def POST(self, format=None, **kwargs):
+        return super(Mo, self).POST(format, useParentUrl=(not self._isTopRoot()), **kwargs)
 
     @property
     def _relativeUrl(self):


### PR DESCRIPTION
- ACI REST API allow to create an MO deep in the hierarchy instead of
  allowing to POST the whole subtree starting from topRoot. Taking
  advantage of this capability. This is beneficial in cases like this
  one, let assume we have a hierarchy like:

<topRoot>
  <polUni>
    <fvTenant name="foo">
      <fvAp name="base">
        <fvAEPg name="lab">
          <fvCEp name="58:F3:9C:89:3A:98">
            <fvIp addr="10.23.143.103">
              <tagAnnotation key="DNS"  value="host.example.local."/>
            </fvIp>
          </fvCEp>
        </fvAEPg>
      </fvAp>
    </fvTenant>
  </polUni>
</topRoot>

  the tagAnnotation can be posted by posting the whole hierarchy under
  "api/mo.xml" or by posting only the necessary MO:

                <tagAnnotation key="DNS"  value="host.example.local."/>

  under "api/mo/uni/tn-foo/ap-base/epg-lab/cep-58:F3:9C:89:3A:98/ip-[10.23.143.103].xml"

 This helps to avoid to construct a nested tree of configuration. The
 reason why this was not working was because the POST method for an MO
 was calculating the URL of the MO itself instead of the parent for
 doing the POST.