### PR TITLE
More query options and proxy support

### DIFF
--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -144,8 +144,10 @@ class Api(object):
         # never use certificate for subscription requests
         if "subscription" not in kwargs:
             self._x509Prep(rootApi, prepped, data)
+        send_kwargs = rootApi._session.merge_environment_settings(
+            prepped.url, proxies={},stream=None, verify=rootApi._verify, cert=None)
         response = rootApi._session.send(
-            prepped, verify=rootApi._verify, timeout=rootApi._timeout)
+            prepped, timeout=rootApi._timeout, **send_kwargs)
 
         logger.debug('<- %d', response.status_code)
         logger.debug('%s', response.text)

--- a/pyaci/options.py
+++ b/pyaci/options.py
@@ -21,6 +21,12 @@ children = ApiOptions([('query-target', 'children')])
 """Query the entire subtree."""
 subtree = ApiOptions([('query-target', 'subtree')])
 
+"""Query the object with all the children."""
+rspSubtreeChildren = ApiOptions([('rsp-subtree', 'children')])
+
+"""Query the object with the entire subtree."""
+rspSubtreeFull = ApiOptions([('rsp-subtree', 'full')])
+
 """Include all the faults along with the entire subtree."""
 faults = ApiOptions([('rsp-subtree-include', 'faults,no-scoped')])
 
@@ -68,3 +74,11 @@ subscribe = ApiOptions([('subscription', 'yes')])
 def filter(filt):
     """Restrict to the specified filter"""
     return ApiOptions([('query-target-filter', str(filt))])
+
+
+def subtreeFilter(filt):
+    """Restrict to the specified filter"""
+    return (ApiOptions([('rsp-subtree-filter', str(filt))]) &
+            ApiOptions([('rsp-subtree-include', 'required')]) &
+            ApiOptions([('rsp-subtree', 'full')]))
+

--- a/pyaci/options.py
+++ b/pyaci/options.py
@@ -21,6 +21,23 @@ children = ApiOptions([('query-target', 'children')])
 """Query the entire subtree."""
 subtree = ApiOptions([('query-target', 'subtree')])
 
+
+def rspSubtreeInclude(level):
+    """Query additional contained objects along in the response e.g. relations, stats, faults"""
+    return ApiOptions([('rsp-subtree-include', level)])
+
+
+def rspSubtreeClass(className):
+    """Query specific"""
+    return (ApiOptions([('rsp-subtree', 'full')]) &
+            ApiOptions([('rsp-subtree-class', className)]))
+
+
+def rspPropInclude(propType):
+    """Query ."""
+    return ApiOptions([('rsp-prop-include', propType)])
+
+
 """Query the object with all the children."""
 rspSubtreeChildren = ApiOptions([('rsp-subtree', 'children')])
 
@@ -81,4 +98,3 @@ def subtreeFilter(filt):
     return (ApiOptions([('rsp-subtree-filter', str(filt))]) &
             ApiOptions([('rsp-subtree-include', 'required')]) &
             ApiOptions([('rsp-subtree', 'full')]))
-

--- a/tests/options-tests.py
+++ b/tests/options-tests.py
@@ -36,3 +36,29 @@ def testPage():
 def testFilter():
     opt = pyaci.options.filter(pyaci.filters.Eq('fvTenant.name', 'cisco'))
     opt['query-target-filter'].should.equal('eq(fvTenant.name,"cisco")')
+
+def testRspSubtreeInclude():
+    opt = pyaci.options.rspSubtreeInclude('relations')
+    opt['rsp-subtree'].should.equal('full')
+    opt['rsp-subtree-include'].should.equal('relations')
+
+def testRspSubtreeClass():
+    opt = pyaci.options.rspSubtreeClass('fvAEPg')
+    opt['rsp-subtree'].should.equal('full')
+    opt['rsp-subtree-class'].should.equal('fvAEPg')
+
+def testRspPropInclude():
+    opt = pyaci.options.rspPropInclude('config-only')
+    opt['rsp-prop-include'].should.equal('config-only')
+
+def testRspSubtreeChildren():
+    opt = pyaci.options.rspSubtreeChildren
+    opt['rsp-subtree'].should.equal('children')
+
+def testRspSubtreeFull():
+    opt = pyaci.options.rspSubtreeFull
+    opt['rsp-subtree'].should.equal('full')
+
+def testSubtreeFilter():
+    opt = pyaci.options.subtreeFilter(pyaci.filters.Eq('fvTenant.name', 'cisco'))
+    opt['rsp-subtree-filter'].should.equal('eq(fvTenant.name,"cisco")')

--- a/tests/options-tests.py
+++ b/tests/options-tests.py
@@ -39,7 +39,6 @@ def testFilter():
 
 def testRspSubtreeInclude():
     opt = pyaci.options.rspSubtreeInclude('relations')
-    opt['rsp-subtree'].should.equal('full')
     opt['rsp-subtree-include'].should.equal('relations')
 
 def testRspSubtreeClass():


### PR DESCRIPTION
APIC has a rich set of options to query the subtree along with the parent MO. This PR will add the additional options as well as the tests. 

Also read the environment variables while sending a request. This is enabled to read the http_proxy and https_proxy from environment variables to send an HTTP request using a proxy.