### PR TITLE
Fix a subscription issue when using cert auth

### DIFF
--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -32,7 +32,8 @@ import time
 try:
     from urllib.parse import unquote, urlparse
 except ImportError:
-    from urllib import unquote, urlparse
+    from urllib import unquote
+    from urlparse import urlparse
 
 from .errors import (
     MetaError, MoError, ResourceError, RestError, UserError


### PR DESCRIPTION
/api/requestAppToken.xml doesn't set the token in the cookies
automatically. Hence, intercept the response and explicitly set the
cookie