### PR TITLE
Do not crash if aci-meta folder exists but has no aci-meta.json

### DIFF
--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -61,18 +61,20 @@ def _elementToString(e):
 
 aciMetaDir = os.path.expanduser(os.environ.get('ACI_META_DIR', '~/.aci-meta'))
 
+# The the folder does not exist: initialize the aciClassMetas as an empty dict
 if not os.path.exists(aciMetaDir):
     aciClassMetas = dict()
 else:
     aciMetaFile = os.path.join(aciMetaDir, 'aci-meta.json')
-    if not os.path.exists(aciMetaFile):
-        raise MetaError('Unable to find ACI meta file {}'.format(aciMetaFile))
-
-    with open(aciMetaFile, 'rb') as f:
-        logger.debug('Loading meta information from %s', aciMetaFile)
-        aciMeta = json.load(f)
-        aciClassMetas = aciMeta['classes']
-
+    # If the folder and the file are present load the aciClassMetas
+    if os.path.exists(aciMetaFile):
+        with open(aciMetaFile, 'rb') as f:
+            logger.debug('Loading meta information from %s', aciMetaFile)
+            aciMeta = json.load(f)
+            aciClassMetas = aciMeta['classes']
+    # The the folder exist but there is no aci-meta.json file: initialize the aciClassMetas as an empty dict
+    else:
+        aciClassMetas = dict()
 
 class Api(object):
     def __init__(self, parentApi=None, userProxies=None):

--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -61,20 +61,14 @@ def _elementToString(e):
 
 aciMetaDir = os.path.expanduser(os.environ.get('ACI_META_DIR', '~/.aci-meta'))
 
-# The the folder does not exist: initialize the aciClassMetas as an empty dict
-if not os.path.exists(aciMetaDir):
-    aciClassMetas = dict()
+aciMetaFile = os.path.join(aciMetaDir, 'aci-meta.json')
+if os.path.exists(aciMetaFile):
+    with open(aciMetaFile, 'rb') as f:
+        logger.debug('Loading meta information from %s', aciMetaFile)
+        aciMeta = json.load(f)
+        aciClassMetas = aciMeta['classes']
 else:
-    aciMetaFile = os.path.join(aciMetaDir, 'aci-meta.json')
-    # If the folder and the file are present load the aciClassMetas
-    if os.path.exists(aciMetaFile):
-        with open(aciMetaFile, 'rb') as f:
-            logger.debug('Loading meta information from %s', aciMetaFile)
-            aciMeta = json.load(f)
-            aciClassMetas = aciMeta['classes']
-    # The the folder exist but there is no aci-meta.json file: initialize the aciClassMetas as an empty dict
-    else:
-        aciClassMetas = dict()
+    aciClassMetas = dict()
 
 class Api(object):
     def __init__(self, parentApi=None, userProxies=None):


### PR DESCRIPTION
Handle the case where the .aci-meta folder exists but has no aci-meta.json.

Currently if the folder does not exists we do `aciClassMetas = dict() ` but if the folder is empty (no aci-meta.json) we raise and error and crash on import. 

This patch makes the behaviour consistent and if the file is not present we simply do `aciClassMetas = dict() `