### PR TITLE
Improve metagen multiprocessing pool lifecycle

### DIFF
--- a/scripts/metagen.py
+++ b/scripts/metagen.py
@@ -74,8 +74,10 @@ def main():
 
     aciMeta = {}
 
-    pool = multiprocessing.Pool(multiprocessing.cpu_count())
-    aciClassMetas = pool.imap(generateClassMeta, classNames)
+    workers = min(6, multiprocessing.cpu_count())
+    with multiprocessing.Pool(processes=workers, maxtasksperchild=600) as pool:
+        aciClassMetas = list(pool.imap(generateClassMeta, classNames, chunksize=1))
+
     aciMeta['classes'] = dict(aciClassMetas)
 
     with open('aci-meta.json', 'w') as out:


### PR DESCRIPTION
Summary bullets:
- refactor metadata generation to use a managed multiprocessing pool context
- cap worker process count to 6 to reduce host contention while preserving parallelism
- set maxtasksperchild and materialize pool output before writing aci-meta.json